### PR TITLE
Fix broken association

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,7 +3,7 @@ class Question < ActiveRecord::Base
   has_many :answers
   has_many :comments, as: :commentable
   has_many :votes, as: :voteable
-  has_one :best_answer, :class_name => "Answer"
+  belongs_to :best_answer, class_name: "Answer", foreign_key: :best_answer_id
 
 
   validates :title, :body, :user_id, { presence: true }


### PR DESCRIPTION
Fixed an issue where even if we didn't have a `question.best_answer_id` we still had a `question.best_answer`