### PR TITLE
Write a virtual questions attribute on comment to allow flexibility when voting

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,4 +1,4 @@
-post '/questions/:id/vote' do 
+post '/questions/:id/vote' do
   question = Question.find_by(id: params[:id])
   vote = question.votes.find_or_create_by(user: current_user)
 
@@ -11,8 +11,6 @@ post '/questions/:id/vote' do
 
   redirect "/questions/#{question.id}"
 end
-
-
 
 post '/answers/:id/vote' do
   answer = Answer.find_by(id: params[:id])
@@ -31,7 +29,6 @@ end
 post '/comments/:id/vote' do
   comment = Comment.find_by(id: params[:id])
   vote = comment.votes.find_or_create_by(user: current_user)
-
   if params[:value].to_i == 0
     vote.destroy
   else
@@ -39,5 +36,5 @@ post '/comments/:id/vote' do
     vote.save
   end
 
-  redirect "/questions/#{comment.commentable.question.id}"
+  redirect "/questions/#{comment.question.id}"
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,4 +9,12 @@ class Comment < ActiveRecord::Base
     votes.sum(:value)
   end
 
+  def question
+    if commentable_type == "Question"
+      return question = commentable
+    elsif commentable_type == "Answer"
+      return question = commentable.question
+    end
+  end
+
 end


### PR DESCRIPTION
We were running into an error where we weren't able to get the question id when redirecting after voting on a comment under a question.

Wrote a virtual attr on comment that returns the question depending on the type of the parent commentable.